### PR TITLE
Create github workflow to update tracking data

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -4,7 +4,8 @@ name: Update
 
 on: 
   schedule:
-    - cron:  '*/15 * * * *'
+    # Run every hour, on the hour.
+    - cron:  '0 * * * *'
 
 jobs:
   update:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,31 @@
+# This workflow archives published data if there are changes every 15m
+
+name: Update
+
+on: 
+  schedule:
+    - cron:  '*/15 * * * *'
+
+jobs:
+  update:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    
+    - name: Download files
+      run: |
+        curl https://covidtracking.com/api/v1/states/current.csv -o data/states_current.csv
+        curl https://covidtracking.com/api/v1/states/daily.csv -o data/states_daily_4pm_et.csv
+        curl https://covidtracking.com/api/v1/states/info.csv -o data/states_info.csv
+        curl https://covidtracking.com/api/us.csv -o data/us_current.csv
+        curl https://covidtracking.com/api/us/daily.csv -o data/us_daily.csv
+        curl https://covidtracking.com/api/counties.csv -o data/counties.csv
+    
+    - name: Commit
+      uses: stefanzweifel/git-auto-commit-action@v4.1.2
+      with:
+        commit_message: Updating public spreadsheet CSV backups
+        file_pattern: data/*.csv


### PR DESCRIPTION
This basically replicates what update-covid-repo.sh does, but runs on github. You can see an example of this running here: https://github.com/smike/covid-tracking-data/runs/570999584?check_suite_focus=true.

I've set this up to run every 15m at this point but that was just a round number. Any better suggestions for update frequency? One thing I noticed is that almost every time this runs, there's some diff. For instance, the lastModified column of data/us_current.csv is constantly changing
