### PR TITLE
Set commit author

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -30,3 +30,4 @@ jobs:
       with:
         commit_message: Updating public spreadsheet CSV backups
         file_pattern: data/*.csv
+        commit_author: GitHub Actions Bot

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -30,4 +30,4 @@ jobs:
       with:
         commit_message: Updating public spreadsheet CSV backups
         file_pattern: data/*.csv
-        commit_author: GitHub Actions Bot
+        commit_author: GitHub Actions <actions@github.com>


### PR DESCRIPTION
By default the repo owner is used, so setting it explicitly should stop polluting @julia326's commit log