### PR TITLE
fix: IN screenshots get cut off w/o hospitalization and probable info

### DIFF
--- a/backup_to_s3.py
+++ b/backup_to_s3.py
@@ -100,13 +100,13 @@ class Screenshotter():
         }
 
         # PhantomJScloud gets the page length wrong for some states, need to set those manually
-        if state in ['ID', 'PA', 'IN', 'CA']:
+        if state in ['ID', 'PA', 'CA']:
             logger.info(f"using larger viewport for state {state}")
             data['renderSettings'] = {'viewport': {'width': 1400, 'height': 3000}}
-        elif state in ['NE']:
+        elif state in ['IN','NE']:
             # really huge viewport for some reason
             logger.info(f"using huge viewport for state {state}")
-            data['renderSettings'] = {'viewport': {'width': 1400, 'height': 5000}}
+            data['renderSettings'] = {'viewport': {'width': 1400, 'height': 7000}}
         elif state in ['UT']:
             # Utah dashboard doesn't render in phantomjscloud unless I set clipRectangle
             data['renderSettings'] = {'clipRectangle': {'width': 1400, 'height': 3000}}


### PR DESCRIPTION
The current page height in IN is just over 7000 from console.log check in my browser https://covidtracking.com/screenshots/IN/IN-20200502-181120.png