### PR TITLE
Add 30 seconds delay to MT primary screenshot

### DIFF
--- a/core_screenshot_config.yaml
+++ b/core_screenshot_config.yaml
@@ -34,6 +34,10 @@ primary:
       await page.waitForFunction(()=>document.querySelector("#main-content").textContent!=="");
       page.done();
     message: clicking button to get rid of popup, using viewport height 8500 for IN
+    
+  MT:
+    overseerScript: page.manualWait(); await page.waitForDelay(30000); page.done();
+    message: waiting 30 sec to load MT  
 
   NE:
     renderSettings:


### PR DESCRIPTION
Sometimes (not often)  it shows up blank

https://covid-tracking-project-data.s3.us-east-1.amazonaws.com/state_screenshots/MT/MT-20200929-002124.png
https://covid-tracking-project-data.s3.us-east-1.amazonaws.com/state_screenshots/MT/MT-20200925-121911.png