### PR TITLE
updating tertiary screenshot for ID and downloading CSV for HI

### DIFF
--- a/core_screenshot_config.yaml
+++ b/core_screenshot_config.yaml
@@ -171,6 +171,23 @@ tertiary:
       page.done();
     message: clicking on "Tests" tab for AR tertiary
 
+  HI:
+    file: csv
+    message: downloading CSV for HI tertiary, to get positive test numbers.
+
+  ID:
+    renderSettings:
+      maxWait: 60000
+    overseerScript: >
+      page.manualWait();
+      await page.waitForDelay(10000);
+      await page.waitForSelector("div#tabZoneId158");
+      await page.hover("div#tabZoneId158");
+      await page.waitForDelay(1000);
+      await page.render.screenshot();        
+      page.done();
+    message: hover logic to show confirmed/probable cases split on statewide demographics dash.
+
   IA:
     overseerScript: page.manualWait(); await page.waitForDelay(60000); page.done();
     message: wait for IA tertiary


### PR DESCRIPTION
Hovering over the top banner for idaho to show confirmed/probable split.
Just downloading the CSV for HI. (spreadsheet change has already been made)