### PR TITLE
adding script for NY tertiary to click press release link

### DIFF
--- a/core_screenshot_config.yaml
+++ b/core_screenshot_config.yaml
@@ -241,6 +241,18 @@ tertiary:
     overseerScript: page.manualWait(); await page.waitForDelay(30000); page.done();
     message: waiting 30 sec to load NJ tertiary
 
+  NY:
+    renderSettings:
+      maxWait: 60000
+    overseerScript: >
+      page.manualWait();
+      await page.waitForSelector("a[href*=\"/news/governor-cuomo-updates-new-yorkers-states-progress-during-covid-19-pandemic-\"]");
+      page.click("a[href*=\"/news/governor-cuomo-updates-new-yorkers-states-progress-during-covid-19-pandemic-\"]");
+      await page.waitForNavigation({waitUntil:"domcontentloaded"});
+      await page.render.screenshot();        
+      page.done();
+    message: click on the first "gov cuomo updates..." link, which should be the latest press release
+ 
   RI:
     file: csv
     message: downloading CSV for RI tertiary


### PR DESCRIPTION
...instead of going straight to press release. The spreadsheet link will need to be updated to point to the main pressroom page instead of trying to build the URL to go straight to the press release.

Building the url to go straight to the press release doesn't work because the press releases are sequentially numbered, but don't happen every day... so we don't know when to increment the number.