### PR TITLE
sending escape key to clear get-your-flu-shot popup from FL page

### DIFF
--- a/core_screenshot_config.yaml
+++ b/core_screenshot_config.yaml
@@ -125,6 +125,19 @@ secondary:
       page.done();
     message: click for DE Total Tests    
 
+  FL:
+    renderSettings:
+      maxWait: 60000
+    overseerScript: >
+      page.manualWait(); 
+      await page.waitForSelector("body.modal-open");
+      await page.waitForDelay(1000); 
+      await page.keyboard.press("Escape");
+      await page.waitForSelector("body:not(.modal-open)");
+      await page.waitForDelay(1000); 
+      page.done();
+    message: clear the 'get your flu shot' pop-up from FL's "what you need to know" page
+
   ID:
     overseerScript: >
       page.manualWait(); 


### PR DESCRIPTION
I thought I had good selectors on the body class, but had to put some small waits for the pop-up to become visible/keypressable and for the pop-up to clear completely. 