### PR TITLE
clearing popup for DC tertiary

### DIFF
--- a/core_screenshot_config.yaml
+++ b/core_screenshot_config.yaml
@@ -207,6 +207,18 @@ tertiary:
       page.done();
     message: clicking on "Tests" tab for AR tertiary
 
+  DC:
+    renderSettings:
+      maxWait: 60000
+    overseerScript: >
+      page.manualWait();
+      await page.waitForSelector("div.mstrd-DossierViewOnboarding-skipBtn");
+      page.click("div.mstrd-DossierViewOnboarding-skipBtn");
+      await page.waitForDelay(5000);
+      page.done();
+    message: clicking skip to get rid of popup for DC, waiting 5 sec
+
+
   HI:
     file: csv
     message: downloading CSV for HI tertiary, to get positive test numbers.


### PR DESCRIPTION
A tutorial pops up the first time you use the dashboard, and it's always the first time in phantomjscloud. : )

Clicking the skip button on the tutorial and waiting a few seconds. 