### PR TITLE
make OH's tertiary screenshot not get cut off

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -257,6 +257,12 @@ tertiary:
       page.done();
     message: click on the first "gov cuomo updates..." link, which should be the latest press release
  
+  OH:
+    renderSettings:
+      viewport:
+        width: 1600
+    message: forcing wider viewPort to avoid clipping
+
   RI:
     file: csv
     message: downloading CSV for RI tertiary


### PR DESCRIPTION
Expanding the viewport. Not sure what the default is, but using 1600 because that's my monitor's width. (and it worked with 5 test runs)