### PR TITLE
fix NC secondary and add quaternary

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -178,6 +178,10 @@ secondary:
       page.done();
     message: clear the "non-covid checkbox for hospitalizations"
 
+  NC:
+    file: pdf
+    message: downloading pdf
+    
   NJ:
     overseerScript: page.manualWait(); await page.waitForDelay(30000); page.done();
     message: waiting 30 sec to load NJ secondary
@@ -333,6 +337,17 @@ quaternary:
   IA:
     overseerScript: page.manualWait(); await page.waitForDelay(60000); page.done();
     message: wait for IA quaternary
+
+  NC:
+    overseerScript: >
+      page.manualWait(); 
+      await page.waitForSelector("a[title='DEATHS by Date of Death'");
+      await page.evaluate(() => { document.querySelector("a[title='DEATHS by Date of Death'").parentElement.firstChild.setAttribute("ctpclickhere", "ctpclickhere"); });
+      page.click("[ctpclickhere]");
+      await page.waitForDelay(5000);
+      page.done();
+
+    message: clicking on "deaths by date of death". Using page.evaluate because I couldn't figure out how to select the sibling.
 
   PR:
     overseerScript: >

--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -342,12 +342,14 @@ quaternary:
     overseerScript: >
       page.manualWait(); 
       await page.waitForSelector("a[title='DEATHS by Date of Death'");
-      await page.evaluate(() => { document.querySelector("a[title='DEATHS by Date of Death'").parentElement.firstChild.setAttribute("ctpclickhere", "ctpclickhere"); });
-      page.click("[ctpclickhere]");
       await page.waitForDelay(5000);
+      await page.evaluate(() => { document.querySelector("a[title='DEATHS by Date of Death'").parentElement.firstChild.setAttribute("ctpclickhere", "ctpclickhere"); });
+      await page.waitForDelay(1000);
+      page.click("[ctpclickhere]");
+      await page.waitForDelay(10000);
       page.done();
 
-    message: clicking on "deaths by date of death". Using page.evaluate because I couldn't figure out how to select the sibling.
+    message: clicking on "deaths by date of death". 
 
   PR:
     overseerScript: >


### PR DESCRIPTION
https://airtable.com/tblUCSoBHVDrqafQY/viwsn5DoZXXQ05w9Z/recVI3YyvozfvsLW1

- fixed secondary by downloading PDF
- added a quaternary based on the suggestion in the card, although not replacing secondary

this change is generally using page.evaluate because I couldn't figure out how to select the sibling (radio button) of the text label, using CSS. The has: pseudoselector would be nice but isn't implemented in browsers yet.