### PR TITLE
change IA timeouts and remove custom url

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -263,7 +263,10 @@ tertiary:
     message: hover logic to show confirmed/probable cases split on statewide demographics dash.
 
   IA:
-    overseerScript: page.manualWait(); await page.waitForDelay(60000); page.done();
+    overseerScript: >
+      page.manualWait(); 
+      await page.waitForDelay(45000); 
+      page.done();
     message: wait for IA tertiary
 
   KY:
@@ -333,7 +336,10 @@ quaternary:
     message: downloading pdf 
 
   IA:
-    overseerScript: page.manualWait(); await page.waitForDelay(60000); page.done();
+    overseerScript: >
+      page.manualWait(); 
+      await page.waitForDelay(45000); 
+      page.done();
     message: wait for IA quaternary
 
   PR:
@@ -346,7 +352,10 @@ quaternary:
 
 quinary:
   IA:
-    overseerScript: page.manualWait(); await page.waitForDelay(60000); page.done();
+    overseerScript: >
+      page.manualWait(); 
+      await page.waitForDelay(45000); 
+      page.done();
     message: wait for IA quinary
 
   PR:

--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -14,12 +14,15 @@ primary:
     message: using viewport height 3000 for ID
 
   IA:
-    url: https://public.domo.com/embed/pages/dPRol
     renderSettings:
       viewport:
         width: 1400
         height: 3000
-    message: loading custom URL and using viewport height 3000 for IA
+    overseerScript: >
+      page.manualWait(); 
+      await page.waitForDelay(30000); 
+      page.done();
+    message: adding manual wait and using viewport height 3000 for IA
 
   IN:
     renderSettings:


### PR DESCRIPTION
Iowa is failing because maxWait is 60000 and we had a waitForDelay of 60000. This change reduces the waitForDelay to give time for other stuff. Another alternative would be to increase maxWait, but 45 seconds seems like plenty...?

I applied this ^ change to all the IA screenshots that had the 60000 wait.

I also added a wait to the primary (which didn't have one previously) because it failed during my testing.

Finally, I removed the custom URL from the primary since I personally think it's better to grab the whole page for a primary. But I'm totally open to be corrected on this.