### PR TITLE
increasing CO timeouts

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -121,7 +121,7 @@ secondary:
   CO:
     overseerScript: >
       page.manualWait(); 
-      await page.waitForDelay(10000); 
+      await page.waitForDelay(30000); 
       page.done();
     message: wait for CO dash to avoid blank screenshots
 
@@ -233,7 +233,7 @@ tertiary:
   CO:
     overseerScript: >
       page.manualWait(); 
-      await page.waitForDelay(10000); 
+      await page.waitForDelay(30000); 
       page.done();
     message: wait for CO dash to avoid blank screenshots
 


### PR DESCRIPTION
Still seeing intermittent blank pages, so increasing timeout to 30 seconds for secondary and tertiary. (haven't seen issues with primary)