### PR TITLE
add longer delay for IL secondary

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -163,9 +163,9 @@ secondary:
       await page.waitForSelector("a.ckeditor-accordion-toggler");
       await page.evaluate(() => { document.evaluate("//a[contains(text(),'Statewide Hospital Statistics1')]", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.setAttribute("ctpclickhere", "ctpclickhere"); });
       page.click("a[ctpclickhere]");
-      await page.waitForDelay(5000);
+      await page.waitForDelay(20000);
       page.done();
-    message: expanding hospital section 
+    message: expanding hospital section, also waiting an extra 20 seconds to make sure other elements render
 
   MA:
     file: pdf


### PR DESCRIPTION
So that other elements on the page can render. (saw 1/10 screenshots with spinners on dashboard)