### PR TITLE
Add tooltip to TN tertiary screenshot

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -310,6 +310,20 @@ tertiary:
     file: csv
     message: downloading CSV for RI tertiary
 
+  TN:
+    url: https://data.tn.gov/t/Public/views/HospitalizedPatients/HospitalizedPatients?:embed=y
+    renderSettings:
+      viewport:
+        width: 1100
+        height: 1400
+    overseerScript: >
+      page.manualWait();
+      await page.waitForDelay(6000);
+      page.mouse.move(999, 672);
+      await page.waitForDelay(1000);
+      page.done();
+    message: hospitalizations for TN tertiary
+
   WI: 
     overseerScript: >
       page.manualWait();

--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -311,7 +311,6 @@ tertiary:
     message: downloading CSV for RI tertiary
 
   TN:
-    url: https://data.tn.gov/t/Public/views/HospitalizedPatients/HospitalizedPatients?:embed=y
     renderSettings:
       viewport:
         width: 1100


### PR DESCRIPTION
Updates the TN tertiary (hospitalization) screenshot to include the tooltip for the latest day.

The url field in YAML is the url to the tableau embed in the current url.

Here's what the new screenshot looks like:

![TN-tertiary-20201031-120420](https://user-images.githubusercontent.com/18607205/97783982-eb189800-1b60-11eb-952f-bd0cfffe0488.png)
