### PR TITLE
[NV] - Curr. Hosp, Curr. ICU, and Curr. Vent

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -433,6 +433,16 @@ quaternary:
 
     message: clicking on 'Antibody Tests - Test Based'. 
 
+  NV:
+    overseerScript: >
+      page.manualWait();
+      await page.waitForDelay(10000);
+      page.mouse.move(920, 406);
+      page.mouse.click(920, 406);
+      await page.waitForDelay(8000);
+      page.done();
+    message: hospitalizations for NV quaternary
+
   PR:
     overseerScript: >
       await page.waitForNavigation({waitUntil:"domcontentloaded"});
@@ -471,3 +481,12 @@ quinary:
       page.click("#ember772");
       page.done();
     message: click button for PR confirmed Deaths ("Muertes Confirmades")
+    
+  NV:
+    overseerScript: >
+      page.manualWait();
+      await page.waitForDelay(10000);
+      page.mouse.move(926, 618);
+      await page.waitForDelay(10000);
+      page.done();
+    message: hover over ICU and ventilators for NV quinary


### PR DESCRIPTION
Quaternary and quinary screenshots for NV now pull from their Hospitalizations by County tab and hover over their respective metrics. For Curr. Hosp., the hover over only reveals the confirmed value. The suspected value may require a separate screenshot.