### PR TITLE
[NY] Hover over hospitalizations and ICU

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -432,6 +432,15 @@ quaternary:
       page.done();
 
     message: clicking on 'Antibody Tests - Test Based'. 
+    
+  NY:
+    overseerScript: >
+      page.manualWait();
+      await page.waitForDelay(10000);
+      page.mouse.move(1061, 1204);
+      await page.waitForDelay(10000);
+      page.done();
+    message: hover over hospitalizations for NY quaternary         
 
   PR:
     overseerScript: >
@@ -463,6 +472,15 @@ quinary:
       await page.waitForDelay(45000); 
       page.done();
     message: wait for IA quinary
+    
+  NY:
+    overseerScript: >
+      page.manualWait();
+      await page.waitForDelay(10000);
+      page.mouse.move(1061, 1212);
+      await page.waitForDelay(10000);
+      page.done();
+    message: hover over ICU for NY quinary             
 
   PR:
     overseerScript: >


### PR DESCRIPTION
Quaternary and quinary screenshots now hover over hospitalizations and ICU numbers, respectively. The quaternary hospitalizations screenshot may need to be change if ICU numbers rise too high.