### PR TITLE
scroll right to see MD's latest serology test

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -328,6 +328,16 @@ tertiary:
       page.done();
     message: expand the columns in the data table
 
+  MD:
+    overseerScript: >
+      page.manualWait(); 
+      await page.waitForDelay(20000);
+      await page.waitForSelector("div.table-responsive");
+      await page.click("div.table-responsive");
+      for (var i = 0; i < 1000; i++) { await page.keyboard.down("ArrowRight"); }
+      page.done();
+    message: Scroll all the way to the right in the data table so we can see the most recent day's column
+
   ME:
     overseerScript: >
       page.manualWait(); 


### PR DESCRIPTION
Scrolling all the way to the right in the data table, because the most recent day is in the last column. Keyboard seems like the most stable/reliable way to do this. 1000 keypresses is way more than we need (30 would do it) but with 1000 we're future proof. : )