### PR TITLE
Add config for AK primary screenshot

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -1,4 +1,11 @@
 primary:
+  AK:
+    overseerScript: >
+      page.manualWait(); 
+      await page.waitForDelay(30000); 
+      page.done();
+    message: waiting 30 sec to load AK primary
+ 
   CA:
     renderSettings:
       viewport:


### PR DESCRIPTION
Tested locally - extended max time gives enough time for first dashboard to load