### PR TITLE
Add a quinary screenshot for AR

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -547,6 +547,19 @@ quaternary:
 
 quinary:
   
+  AR:
+    renderSettings:
+      clipRectangle:
+        width: 1400
+        height: 1400
+    overseerScript: >
+      page.manualWait();
+      await page.waitForSelector("span.ember-view.tab-title:nth-of-type(3)");
+      page.click("span.ember-view.tab-title:nth-of-type(3)");
+      await page.waitForDelay(10000);
+      page.done();
+    message: clicking on "Deaths" tab for AR quinary
+    
   HI: 
     renderSettings:
       maxWait: 90000


### PR DESCRIPTION
Tested locally - add quinary screenshot to capture "Deaths" tab for AR