### PR TITLE
first cut at screenshot config generator

### DIFF
--- a/screenshots/generate_new_configs.py
+++ b/screenshots/generate_new_configs.py
@@ -80,6 +80,8 @@ def output_yamls(team, state_urls, config_basename):
                         # each statement on its own line
                         for command in overseer_script.split(';'):
                             command = command.strip()
+                            if '{' in command:
+                                command = command.replace('{', '{\n     ')
                             if command:
                                 outfile.write("    %s;\n" % command)
                     if "renderSettings" in existing_state_config:

--- a/screenshots/generate_new_configs.py
+++ b/screenshots/generate_new_configs.py
@@ -57,7 +57,7 @@ def output_yamls(team, state_urls, config_basename):
         with open(destination_directory + "/" + state + '.yaml', 'w+') as outfile:
 
             outfile.write("state: " + state + "\n")
-            outfile.write("links: " + "\n")
+            outfile.write("links: " + "\n\n")
 
             # walk through the URLs for the state, and merge with config from the old YAMLs
             new_config_list = []
@@ -75,10 +75,11 @@ def output_yamls(team, state_urls, config_basename):
                 if(existing_state_config): # if there is a config from the previous yaml, use that and add name and url
                     if(existing_state_config.get("overseerScript")):
                         overseerscript_string = existing_state_config["overseerScript"]
-                        overseerscript_string = overseerscript_string.replace("\n", "\n    ", overseerscript_string.count("\n")-1)
+                        if overseerscript_string[-1] == "\n": overseerscript_string = overseerscript_string[:-1] 
+                        overseerscript_string = overseerscript_string.replace("\n", "\n    ") # indent
                         outfile.write("  overseerScript: |\n    " + overseerscript_string + "\n")
                     if(existing_state_config.get("renderSettings")):
-                        outfile.write("  renderSettings: \n    " + yaml.dump(existing_state_config["renderSettings"], default_flow_style=False, indent=6) + "\n")
+                        outfile.write("  renderSettings: \n    " + yaml.dump(existing_state_config["renderSettings"], default_flow_style=False, indent=6))
 
                 outfile.write("\n")
     

--- a/screenshots/generate_new_configs.py
+++ b/screenshots/generate_new_configs.py
@@ -72,14 +72,19 @@ def output_yamls(team, state_urls, config_basename):
                 outfile.write("- name: " + url_name + "\n")
                 outfile.write("  url: " + url_text + "\n")
 
-                if(existing_state_config): # if there is a config from the previous yaml, use that and add name and url
-                    if(existing_state_config.get("overseerScript")):
-                        overseerscript_string = existing_state_config["overseerScript"]
-                        if overseerscript_string[-1] == "\n": overseerscript_string = overseerscript_string[:-1] 
-                        overseerscript_string = overseerscript_string.replace("\n", "\n    ") # indent
-                        outfile.write("  overseerScript: |\n    " + overseerscript_string + "\n")
-                    if(existing_state_config.get("renderSettings")):
-                        outfile.write("  renderSettings: \n    " + yaml.dump(existing_state_config["renderSettings"], default_flow_style=False, indent=6))
+                if existing_state_config:
+                    if "overseerScript" in existing_state_config:
+                        outfile.write("  overseerScript: |\n")
+                        # strip newlines
+                        overseer_script = existing_state_config["overseerScript"].strip()
+                        # each statement on its own line
+                        for command in overseer_script.split(';'):
+                            command = command.strip()
+                            if command:
+                                outfile.write("    %s;\n" % command)
+                    if "renderSettings" in existing_state_config:
+                        outfile.write("  renderSettings: \n    " + yaml.dump(
+                            existing_state_config["renderSettings"], default_flow_style=False, indent=6))
 
                 outfile.write("\n")
     

--- a/screenshots/generate_new_configs.py
+++ b/screenshots/generate_new_configs.py
@@ -45,11 +45,14 @@ def output_yamls(team, state_urls, config_basename):
         existing_config = yaml.safe_load(f)
 
     # set up the output directory
-    destination_directory = "./configs/" + team + "/"
+    destination_directory = "./config/" + team + "/"
     os.makedirs(destination_directory, exist_ok=True)
 
     # walk through the states from the spreadsheet
     for state, urls in state_urls.items():
+
+        # open a file for the current state, creating the file if it doesn't exist
+        outfile = open(destination_directory + state + '.yaml', 'w+')
 
         # walk through the URLs for the state, and merge with config from the old YAMLs
         new_config_list = []
@@ -59,17 +62,19 @@ def output_yamls(team, state_urls, config_basename):
             if(urltext):
                 existing_state_config = existing_config[urlname].get(state)
                 
-                if(existing_state_config): # if there is a config from the previous yaml, use that and add name and url
-                    existing_state_config["name"] = urlname
-                    existing_state_config["url"] = urltext
-                else:  # if not, create a new config with just name and url
-                    existing_state_config = { "url": urltext, "name": urlname }
+                outfile.write("- name: " + urlname + "\n")
+                outfile.write("  url: " + urltext + "\n")
 
-                new_config_list.append(existing_state_config)                
-        
-        # write the current state to its file, creating the file if it doesn't exist
-        with open(destination_directory + state + '.yaml', 'w+') as file:
-            documents = yaml.dump(new_config_list, file, default_flow_style=False)
+                if(existing_state_config): # if there is a config from the previous yaml, use that and add name and url
+                    if(existing_state_config.get("overseerScript")):
+                        overseerScriptString = existing_state_config["overseerScript"]
+                        overseerScriptString = overseerScriptString.replace("\n", "\n    ", overseerScriptString.count("\n")-1)
+                        outfile.write("  overseerScript: |\n    " + overseerScriptString + "\n")
+                    if(existing_state_config.get("renderSettings")):
+                        outfile.write("  renderSettings: \n    " + yaml.dump(existing_state_config["renderSettings"], default_flow_style=False, indent=6) + "\n")
+
+                outfile.write("\n")
+    
 
 
 def main(args_list=None):

--- a/screenshots/generate_new_configs.py
+++ b/screenshots/generate_new_configs.py
@@ -1,0 +1,89 @@
+import os
+import io
+import pandas as pd
+import requests
+import yaml
+
+def load_urls_from_live_info(url):
+
+    content = requests.get(url).content
+    state_info_df = pd.read_csv(io.StringIO(content.decode('utf-8')), keep_default_na=False)
+    
+    state_urls = {}
+    for idx, r in state_info_df.iterrows():
+        state_urls[r["state"]] = {
+            'primary': r["covid19Site"],
+            'secondary': r["covid19SiteSecondary"],
+            'tertiary': r["covid19SiteTertiary"],
+            'quaternary': r["covid19SiteQuaternary"],
+            'quinary': r["covid19SiteQuinary"],
+        }
+
+    return state_urls
+
+
+def load_urls_from_spreadsheet(csv_url):
+
+    urls_df = pd.read_csv(csv_url, keep_default_na=False)
+
+    state_urls = {}
+    for idx, row in urls_df.iterrows():
+        state_urls[row['State']] = {
+            'primary': row['Link 1'],
+            'secondary': row['Link 2'],
+            'tertiary': row['Link 3'],
+        }
+
+    return state_urls
+
+# construct an array containing the URL configs (up to 5) for each state (including the URL, name and existing YAML config)
+# then dump that dictionary to a new YAML file named after the state, in the appropriate directory
+def output_yamls(team, state_urls, config_basename):
+    
+    screenshot_config_path = os.path.join(os.path.dirname(__file__), 'configs', config_basename)
+    with open(screenshot_config_path) as f:
+        existing_config = yaml.safe_load(f)
+
+    # set up the output directory
+    destination_directory = "./configs/" + team + "/"
+    os.makedirs(destination_directory, exist_ok=True)
+
+    # walk through the states from the spreadsheet
+    for state, urls in state_urls.items():
+
+        # walk through the URLs for the state, and merge with config from the old YAMLs
+        new_config_list = []
+        for urlname, urltext in urls.items():
+            
+            # if there's no URL, that means there was an empty cell in the spreadsheet
+            if(urltext):
+                existing_state_config = existing_config[urlname].get(state)
+                
+                if(existing_state_config): # if there is a config from the previous yaml, use that and add name and url
+                    existing_state_config["name"] = urlname
+                    existing_state_config["url"] = urltext
+                else:  # if not, create a new config with just name and url
+                    existing_state_config = { "url": urltext, "name": urlname }
+
+                new_config_list.append(existing_state_config)                
+        
+        # write the current state to its file, creating the file if it doesn't exist
+        with open(destination_directory + state + '.yaml', 'w+') as file:
+            documents = yaml.dump(new_config_list, file, default_flow_style=False)
+
+
+def main(args_list=None):
+
+    state_urls = load_urls_from_live_info('https://covidtracking.com/api/states/info.csv')
+    output_yamls("taco", state_urls, 'core_screenshot_config.yaml')
+
+    state_urls = load_urls_from_spreadsheet('https://docs.google.com/spreadsheets/d/1lfwMmo7q-faKfvh6phxQs9rEJXVnnyISFtiVbq9XJ7U/gviz/tq?tqx=out:csv&sheet=Sheet1')
+    output_yamls("crdt", state_urls, 'crdt_screenshot_config.yaml')
+
+    state_urls = load_urls_from_spreadsheet('https://docs.google.com/spreadsheets/d/1kB6lT0n4wJ2l8uP-lIOZyIVWCRJTPWLGf3Q4ZCC6pMQ/gviz/tq?tqx=out:csv&sheet=LTC_Screencap_Links')
+    output_yamls("ltc", state_urls, 'ltc_screenshot_config.yaml')
+
+
+    
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Open issues / questions:

- do we need command line params? I figure they're unnecessary because this will basically be run a few times by one or two people. Note that it currently puts the output in ./config/.
- output is not as readable as the current YAMLs are, as I'm having trouble getting pyyaml to do nice formatting. These are the main issues:

1. newlines in overseerScript are not getting preserved through the read/write. 
1. no breaks between screenshots in the same file, which would be nice for separation
1. order of the dictionary items for a given screenshot (name, url, etc.)  is alphabetical, and probably not guaranteed. It would be nice to have "name" first, then url etc.
1. I'm using a list for the screenshots within a state, so each screenshot has a "-" before it. If we could fix all the above, this would be no problem imo.

There are other yaml load/dump libraries that we can try, or it would be simple to implement our own. I'll play around with other libraries, but lmk if you have ideas.