### PR TITLE
AZ quinary - confirmed and probable deaths

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -579,7 +579,6 @@ quinary:
     overseerScript: >
       page.manualWait();
       await page.waitForDelay(10000);
-      page.mouse.move(880, 1100);
       page.mouse.click(880, 1100);
       await page.waitForDelay(15000);
       page.done();

--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -574,6 +574,16 @@ quinary:
       await page.waitForDelay(10000);
       page.done();
     message: clicking on "Deaths" tab for AR quinary
+
+  AZ:
+    overseerScript: >
+      page.manualWait();
+      await page.waitForDelay(10000);
+      page.mouse.move(880, 1100);
+      page.mouse.click(880, 1100);
+      await page.waitForDelay(15000);
+      page.done();
+    message: hovering over and clicking on deaths for AZ quinary
     
   HI: 
     renderSettings:


### PR DESCRIPTION
Hovers over and clicks on deaths to show confirmed/probable split in quinary screenshot