### PR TITLE
Update core_screenshot_config.yaml

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -58,9 +58,9 @@ primary:
   
   ND:
     renderSettings:
-      maxWait: 150000
-    overseerScript: page.manualWait(); await page.waitForDelay(120000); page.done();
-    message: waiting for 120 seconds to load ND
+      maxWait: 180000
+    overseerScript: page.manualWait(); await page.waitForDelay(150000); page.done();
+    message: waiting for 150 seconds to load ND
    
   NE:
     renderSettings:


### PR DESCRIPTION
Adding another 30 seconds to the ND wait, it's working about 80% of the time now, hopefully this should get us up to 100%.