### PR TITLE
[MI] Adding quaternary screenshot to reliably capture dash

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -511,6 +511,10 @@ quaternary:
       await page.waitForDelay(10000);
       page.done();
     message: clicking confirmed cases in dropdown
+
+  MI:
+    overseerScript: page.manualWait(); await page.waitForDelay(30000); page.done();
+    message: waiting for MI quaternary
    
   NC:
     overseerScript: >


### PR DESCRIPTION
Primary screenshot should capture embedded dash but dash frequently does not load, even after a 60 second wait. Adding a quaternary screenshot of the dashboard itself for reliable capture.