### PR TITLE
Changing #ember65 to #ember69 for PA Secondary Screenshot

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -275,8 +275,8 @@ secondary:
   PA:
     overseerScript: >
       page.manualWait();
-      await page.waitForSelector("#ember65");
-      page.click("#ember65"); 
+      await page.waitForSelector("#ember69");
+      page.click("#ember69"); 
       await page.waitForDelay(30000);
       page.done();
     message: custom click logic for PA secondary dashboard


### PR DESCRIPTION
To capture "hospital preparedness" instead of "zip code case data"