### PR TITLE
Update AZ Primary and Quinary Screenshots

### DIFF
--- a/screenshots/configs/core_screenshot_config.yaml
+++ b/screenshots/configs/core_screenshot_config.yaml
@@ -11,7 +11,7 @@ primary:
       page.manualWait();
       await page.waitForDelay(10000);
       page.mouse.click(615, 1100);
-      await page.waitForDelay(20000);
+      await page.waitForDelay(30000);
       page.done();
     message: clicking on cases for AZ primary
  
@@ -723,7 +723,7 @@ quinary:
       page.manualWait();
       await page.waitForDelay(10000);
       page.mouse.click(880, 1100);
-      await page.waitForDelay(20000);
+      await page.waitForDelay(30000);
       page.done();
     message: clicking on deaths for AZ quinary
 


### PR DESCRIPTION
Changing second await page.waitForDelay() from 20000 to 30000. More reliable - tested locally!