### PR TITLE
UT LTC: add #positives for unresolved outbreaks

### DIFF
--- a/data-collection-scripts/ltc-scrapers/python-scrapers/ut_ltc_scraper.py
+++ b/data-collection-scripts/ltc-scrapers/python-scrapers/ut_ltc_scraper.py
@@ -52,6 +52,7 @@ for facility in dict_data["features"]:
 
     facility["Date Collected"] = datetime.now(timezone('US/Eastern')).strftime('%Y%m%d')
     facility["State"] = "UT"
+    facility["Unresolved_Postive_Patients_Desc"] = facility["Postive_Patients_Desc"] if facility["Resolved_Y_N"] == "N" else ""
     facility["blank"] = ""
     writer.writerow(facility)
 


### PR DESCRIPTION
Adding one more bit of this, on request from Artis:
>And to tack on another request. If a facility is list listed as Resolved_N = N, can you also add that facilities desc data to column [W] as well. And if it = Y, then just leave it in column [O].