### PR TITLE
fix: vax timeseries missing data because of git shallow clone

### DIFF
--- a/.github/workflows/update_timeseries.yml
+++ b/.github/workflows/update_timeseries.yml
@@ -13,6 +13,8 @@ jobs:
       runs-on: ubuntu-20.04
       steps:
         - uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
         - uses: actions/cache@v2
           with:
             path: ~/.cache/pip


### PR DESCRIPTION
I think this works? 