### PR TITLE
Add LTC vaccine timeseries

### DIFF
--- a/.github/workflows/update_timeseries.yml
+++ b/.github/workflows/update_timeseries.yml
@@ -31,14 +31,16 @@ jobs:
             if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         - name: Run script
           run: |
-            python make_timeseries.py > ../../data/cdc_vaccinations_timeseries.csv
-            python make_timeseries.py --strip-duplicate-days > ../../data/cdc_vaccinations_timeseries_daily.csv
+            python make_timeseries.py data/cdc_vaccinations.json vaccination_data > ../../data/cdc_vaccinations_timeseries.csv
+            python make_timeseries.py data/cdc_vaccinations.json vaccination_data --strip-duplicate-days > ../../data/cdc_vaccinations_timeseries_daily.csv
+            python make_timeseries.py data/cdc_vaccinations_ltc.json vaccination_ltc_data > ../../data/cdc_vaccinations_ltc_timeseries.csv
+            python make_timeseries.py data/cdc_vaccinations_ltc.json vaccination_ltc_data --strip-duplicate-days > ../../data/cdc_vaccinations_ltc_timeseries_daily.csv
         - name: Commit
           if: github.ref == 'refs/heads/master'
           uses: EndBug/add-and-commit@v5
           with:
             message: Updating timeseries
-            add: 'data/cdc_vaccinations_timeseries*'
+            add: 'data/cdc_vaccinations*'
             author_name: GitHub Actions
             author_email: actions@github.com
           env:

--- a/data-collection-scripts/cdc-vaccinations-timeseries/make_timeseries.py
+++ b/data-collection-scripts/cdc-vaccinations-timeseries/make_timeseries.py
@@ -12,17 +12,18 @@ if sys.version_info < MIN_PYTHON:
 
 
 @click.command()
+@click.argument('filename')
+@click.argument('json_key')
 @click.option('--strip-duplicate-days/--no-strip-duplicate-days', default=False,
               help='Process the data to only output one set of data for each day')
-def main(strip_duplicate_days):
+def main(filename, json_key, strip_duplicate_days):
     repo = git.Repo("../../")
-    path = "data/cdc_vaccinations.json"
 
     # fetch all the git commits that updated the data file
     # thanks to https://stackoverflow.com/q/28803626
     revlist = (
-        (commit, (commit.tree / path).data_stream.read())
-        for commit in repo.iter_commits(paths=path)
+        (commit, (commit.tree / filename).data_stream.read())
+        for commit in repo.iter_commits(paths=filename)
     )
 
     # build up a dict of the data history by looking at each commit in the git history
@@ -36,7 +37,7 @@ def main(strip_duplicate_days):
     out_cols = {"runid": None}
     seen_data = defaultdict(set)  # dict with date keys holding the states we've seen for that date
     for data_time, data_batch in data.items():
-        for state_data in data_batch["vaccination_data"]:
+        for state_data in data_batch[json_key]:
             state_data["runid"] = data_batch["runid"]
 
             # there's an anomaly in the data where one day has the date in the wrong format.

--- a/data/README.md
+++ b/data/README.md
@@ -26,7 +26,9 @@ The following files are stored under the same file in this repo, so to see chang
 - Vaccination data in a more convenient CSV time series format, processed by the script in `/data-collection-scripts/cdc_vaccination_timeseries.py` and saved to [cdc_vaccines_timeseries.csv](https://github.com/COVID19Tracking/covid-tracking-data/blob/master/data/cdc_vaccines_timeseries.csv). 
 We also process this data into [cdc_vaccines_timeseries_daily.csv](https://github.com/COVID19Tracking/covid-tracking-data/blob/master/data/cdc_vaccines_timeseries_daily.csv), where multiple updates from the same date are reduced to the most recent data only.
 - US COVID-19 Cases Caused by Variants: https://www.cdc.gov/coronavirus/2019-ncov/transmission/variant-cases.html, saved to [cdc_variants.json](https://github.com/COVID19Tracking/covid-tracking-data/blob/master/data/cdc_variants.json)
-- Long-term Care Facility Vaccination data: https://covid.cdc.gov/covid-data-tracker/#vaccinations-ltc, saved to [cdc_vaccinations_ltc.json](https://github.com/COVID19Tracking/covid-tracking-data/blob/master/data/cdc_vaccinations_ltc.json)
+- Long-term Care Facility Vaccination data: https://covid.cdc.gov/covid-data-tracker/#vaccinations-ltc, saved to [cdc_vaccinations_ltc.json](https://github.com/COVID19Tracking/covid-tracking-data/blob/master/data/cdc_vaccinations_ltc.json). 
+  This data is also available processed into a CSV time series format in [cdc_vaccines_ltc_timeseries.csv](https://github.com/COVID19Tracking/covid-tracking-data/blob/master/data/cdc_vaccines_ltc_timeseries.csv) 
+  and [cdc_vaccines_ltc_timeseries_daily.csv](https://github.com/COVID19Tracking/covid-tracking-data/blob/master/data/cdc_vaccines_ltc_timeseries_daily.csv)
 - CDC testing data, saved to [cdc_testing.json](https://github.com/COVID19Tracking/covid-tracking-data/commits/master/data/cdc_testing.json)
 
 We have saved, but are no longer updating, older CDC case, testing and deaths data. To see how these files had changed in the past, see the GitHub history as follows:


### PR DESCRIPTION
Refactor make_timeseries to work against any CDC JSON dataset

I [tested this on a fork](https://github.com/zachlipton/covid-tracking-data/tree/master/data) since it's otherwise irritating to test