### PR TITLE
Add backups of CTP annotations

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,7 +27,8 @@ jobs:
         curl -L "https://docs.google.com/spreadsheets/d/1MvvbHfnjF67GnYUDJJiNYUmGco5KQ9PW0ZRnEP9ndlU/pub?gid=115892946&single=true&output=csv" -o data/states_matrix.csv
         curl -L "https://docs.google.com/spreadsheets/d/1tq_treJNLepYmhZzGtWCPJe8NS2w1qEpXfEoyfRVsWk/pub?gid=43720681&single=true&output=csv" -o data/crdt.csv
         curl -L "https://docs.google.com/spreadsheets/d/1Kyn3w9_NPYcjNO8a0QMtH6tQhkcFWi0wJdJ92sywMnI/gviz/tq?tqx=out:csv&sheet=Data_v2" -o data/ltc.csv
-    
+        curl -L "https://docs.google.com/spreadsheets/d/e/2PACX-1vS1uScYv8SWYhY2cTPoaLUbsTh8Nr3CcCbs07HEpQXflvxkvieHQIFHBGPocxO-uetmfJuQuryPcQtT/pub?gid=1968155885&single=true&output=csv" -o data/annotations.csv
+
     - name: Commit
       uses: stefanzweifel/git-auto-commit-action@v4.1.2
       with:


### PR DESCRIPTION
This is a slightly convoluted process where Airtable is imported into a sheet which is formatted the way Michal wants it, which is is archived, but it's archiving the the right things. 