### PR TITLE
Fix CDC variant regex

### DIFF
--- a/.github/workflows/update_hhs.yml
+++ b/.github/workflows/update_hhs.yml
@@ -2,44 +2,41 @@
 
 name: Update HHS and CDC files
 
-on: 
+on:
   schedule:
     # Run every hour, on the half-hour.
     - cron:  '30 * * * *'
 
 jobs:
   update:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
-    
-    - name: Download HHS and CDC files
-      run: |
-        curl https://healthdata.gov/api/views/6xf2-c3ie/rows.csv?accessType=DOWNLOAD -o data/hhs/reported_hospital_utilization_$(TZ=America/New_York date '+%Y%m%d').csv
-        curl https://healthdata.gov/api/views/g62h-syeh/rows.csv?accessType=DOWNLOAD -o data/hhs/reported_hospital_utilization_timeseries_$(TZ=America/New_York date '+%Y%m%d').csv
-        curl https://healthdata.gov/api/views/j8mb-icvb/rows.csv?accessType=DOWNLOAD -o data/hhs/covid-19_diagnostic_lab_testing_$(TZ=America/New_York date '+%Y%m%d').csv
-        curl https://healthdata.gov/api/views/anag-cw7u/rows.csv?accessType=DOWNLOAD -o data/hhs/reported_hospital_capacity_admissions_facility_level_weekly_average_timeseries_$(TZ=America/New_York date '+%Y%m%d').csv
 
-        curl https://healthdata.gov/api/views/7ctx-gtb7/rows.csv?accessType=DOWNLOAD -o data/hhs/estimated_icu_$(TZ=America/New_York date '+%Y%m%d').csv
-        curl https://healthdata.gov/api/views/jjp9-htie/rows.csv?accessType=DOWNLOAD -o data/hhs/estimated_inpatient_all_$(TZ=America/New_York date '+%Y%m%d').csv
-        curl https://healthdata.gov/api/views/py8k-j5rq/rows.csv?accessType=DOWNLOAD -o data/hhs/estimated_inpatient_covid_$(TZ=America/New_York date '+%Y%m%d').csv
+    - run:  curl https://healthdata.gov/api/views/6xf2-c3ie/rows.csv?accessType=DOWNLOAD -o data/hhs/reported_hospital_utilization_$(TZ=America/New_York date '+%Y%m%d').csv
+    - run:  curl https://healthdata.gov/api/views/g62h-syeh/rows.csv?accessType=DOWNLOAD -o data/hhs/reported_hospital_utilization_timeseries_$(TZ=America/New_York date '+%Y%m%d').csv
+    - run:  curl https://healthdata.gov/api/views/j8mb-icvb/rows.csv?accessType=DOWNLOAD -o data/hhs/covid-19_diagnostic_lab_testing_$(TZ=America/New_York date '+%Y%m%d').csv
+    - run:  curl https://healthdata.gov/api/views/anag-cw7u/rows.csv?accessType=DOWNLOAD -o data/hhs/reported_hospital_capacity_admissions_facility_level_weekly_average_timeseries_$(TZ=America/New_York date '+%Y%m%d').csv
 
-        curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=vaccination_data -o data/cdc_vaccinations.json
-        curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=US_MAP_TESTING -o data/cdc_testing.json
-        curl https://data.cdc.gov/api/views/9mfq-cb36/rows.csv?accessType=DOWNLOAD -o data/cdc_cases_deaths.csv
-        curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=integrated_county_latest_external_data -o data/cdc_counties.csv
-        curl https://www.cdc.gov/coronavirus/2019-ncov/modules/lineage-cases.json -o data/cdc_b117_cases.json
-        curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=vaccination_ltc_data -o data/cdc_vaccinations_ltc.json
-        curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=vaccination_trends_data -o data/cdc_vaccination_trends.json
-        curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=vaccination_demographics_data -o data/cdc_vaccinations_demographics.json
-        curl https://healthdata.gov/api/views/di4u-7yu6/rows.csv?accessType=DOWNLOAD -o data/hhs/community_profile_counties_$(TZ=America/New_York date '+%Y%m%d').csv
-        CDC_VARIANT_LINK=`curl -k https://www.cdc.gov/coronavirus/2019-ncov/transmission/variant-cases.html | grep -Eo "/coronavirus.+?\.csv"`
+    - run:  curl https://healthdata.gov/api/views/7ctx-gtb7/rows.csv?accessType=DOWNLOAD -o data/hhs/estimated_icu_$(TZ=America/New_York date '+%Y%m%d').csv
+    - run:  curl https://healthdata.gov/api/views/jjp9-htie/rows.csv?accessType=DOWNLOAD -o data/hhs/estimated_inpatient_all_$(TZ=America/New_York date '+%Y%m%d').csv
+    - run:  curl https://healthdata.gov/api/views/py8k-j5rq/rows.csv?accessType=DOWNLOAD -o data/hhs/estimated_inpatient_covid_$(TZ=America/New_York date '+%Y%m%d').csv
+
+    - run:  curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=vaccination_data -o data/cdc_vaccinations.json
+    - run:  curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=US_MAP_TESTING -o data/cdc_testing.json
+    - run:  curl https://data.cdc.gov/api/views/9mfq-cb36/rows.csv?accessType=DOWNLOAD -o data/cdc_cases_deaths.csv
+    - run:  curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=integrated_county_latest_external_data -o data/cdc_counties.csv
+    - run:  curl https://www.cdc.gov/coronavirus/2019-ncov/modules/lineage-cases.json -o data/cdc_b117_cases.json
+    - run:  curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=vaccination_ltc_data -o data/cdc_vaccinations_ltc.json
+    - run:  curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=vaccination_trends_data -o data/cdc_vaccination_trends.json
+    - run:  curl https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=vaccination_demographics_data -o data/cdc_vaccinations_demographics.json
+    - run:  curl https://healthdata.gov/api/views/di4u-7yu6/rows.csv?accessType=DOWNLOAD -o data/hhs/community_profile_counties_$(TZ=America/New_York date '+%Y%m%d').csv
+    - run: |
+        CDC_VARIANT_LINK=`curl -k https://www.cdc.gov/coronavirus/2019-ncov/transmission/variant-cases.html | grep -Eo "\/coronavirus.+?\.xls"`
         curl https://www.cdc.gov$CDC_VARIANT_LINK -o data/cdc_variant_cases.csv
-        curl "https://data.cdc.gov/api/views/r8kw-7aab/rows.csv?accessType=DOWNLOAD" -o data/cdc_provisional_deaths.csv
-
+    - run:  curl "https://data.cdc.gov/api/views/r8kw-7aab/rows.csv?accessType=DOWNLOAD" -o data/cdc_provisional_deaths.csv
     - name: Commit
       uses: stefanzweifel/git-auto-commit-action@v4.1.2
       with:


### PR DESCRIPTION
- Split all the actions up into separate steps so it’s possible to see which one fails without pain
- The file extension claims it’s an XLS, but it lies and is really a CSV